### PR TITLE
added bastion-secops-sbox configuration to terraform

### DIFF
--- a/terraform/environment/sbox/21-bastion.tf
+++ b/terraform/environment/sbox/21-bastion.tf
@@ -12,3 +12,14 @@ module "bastion-sbox" {
   create_disks        = true
   install_splunk_uf   = true
 }
+module "bastion-secops" {
+  source              = "../../modules/bastion/"
+  location            = module.bootstrap.resource_group.location
+  environment         = local.environment
+  image_version       = local.image_version
+  resource_group_name = module.bootstrap.resource_group.name
+  subnet_id           = module.bootstrap.subnet.id
+  keyvault_id         = module.bootstrap.keyvault.id
+  bastion_name        = "bastion-secops-sbox"
+  install_splunk_uf   = true
+}

--- a/terraform/environment/sbox/21-bastion.tf
+++ b/terraform/environment/sbox/21-bastion.tf
@@ -12,6 +12,8 @@ module "bastion-sbox" {
   create_disks        = true
   install_splunk_uf   = true
 }
+
+# Configuration for SecOps bastion
 module "bastion-secops-sbox" {
   source              = "../../modules/bastion/"
   location            = module.bootstrap.resource_group.location

--- a/terraform/environment/sbox/21-bastion.tf
+++ b/terraform/environment/sbox/21-bastion.tf
@@ -12,7 +12,7 @@ module "bastion-sbox" {
   create_disks        = true
   install_splunk_uf   = true
 }
-module "bastion-secops" {
+module "bastion-secops-sbox" {
   source              = "../../modules/bastion/"
   location            = module.bootstrap.resource_group.location
   environment         = local.environment

--- a/terraform/environment/sbox/rbac/20-rbac.tf
+++ b/terraform/environment/sbox/rbac/20-rbac.tf
@@ -1,5 +1,5 @@
 module "bastion-secops-sbox-rbac" {
-  source                          = "../../../modules/rbac/"
+  source = "../../../modules/rbac/"
   depends_on = [
     module.bastion-secops-sbox
   ]

--- a/terraform/environment/sbox/rbac/20-rbac.tf
+++ b/terraform/environment/sbox/rbac/20-rbac.tf
@@ -1,5 +1,8 @@
 module "bastion-secops-sbox-rbac" {
   source                          = "../../../modules/rbac/"
+  depends_on = [
+    module.bastion-secops-sbox
+  ]
   bastion_vm_name                 = "bastion-secops-sbox"
   bastion_resource_group          = "bastion-sbox-rg"
   bastion_access_admin_group_name = "DTS Non-Production Bastion Access for Administrators (SecOps)"

--- a/terraform/environment/sbox/rbac/20-rbac.tf
+++ b/terraform/environment/sbox/rbac/20-rbac.tf
@@ -4,7 +4,7 @@ module "bastion-secops-rbac" {
   bastion_resource_group          = "bastion-sbox-rg"
   bastion_access_admin_group_name = "DTS Non-Production Bastion Access for Administrators (SecOps)"
   bastion_access_user_group_name  = "DTS Non-Production Bastion Access for Users (SecOps)"
-  bastion_subscription_id         = "2b1afc19-5ca9-4796-a56f-574a58670244"
+  bastion_subscription_id         = "b3394340-6c9f-44ca-aa3e-9ff38bd1f9ac"
   aad_role_def_id_admin           = "/subscriptions/b3394340-6c9f-44ca-aa3e-9ff38bd1f9ac/providers/Microsoft.Authorization/roleDefinitions/1c0163c0-47e6-4577-8991-ea5c82e286e4"
   aad_role_def_id_user            = "/subscriptions/b3394340-6c9f-44ca-aa3e-9ff38bd1f9ac/providers/Microsoft.Authorization/roleDefinitions/fb879df8-f326-4884-b1cf-06f3ad86be52"
 }

--- a/terraform/environment/sbox/rbac/20-rbac.tf
+++ b/terraform/environment/sbox/rbac/20-rbac.tf
@@ -1,3 +1,4 @@
+/*
 module "bastion-secops-sbox-rbac" {
   source = "../../../modules/rbac/"
   bastion_vm_name                 = "bastion-secops-sbox"
@@ -8,6 +9,7 @@ module "bastion-secops-sbox-rbac" {
   aad_role_def_id_admin           = "/subscriptions/b3394340-6c9f-44ca-aa3e-9ff38bd1f9ac/providers/Microsoft.Authorization/roleDefinitions/1c0163c0-47e6-4577-8991-ea5c82e286e4"
   aad_role_def_id_user            = "/subscriptions/b3394340-6c9f-44ca-aa3e-9ff38bd1f9ac/providers/Microsoft.Authorization/roleDefinitions/fb879df8-f326-4884-b1cf-06f3ad86be52"
 }
+*/
 module "bastion-sbox-rbac" {
   source                          = "../../../modules/rbac/"
   bastion_vm_name                 = "bastion-sbox"

--- a/terraform/environment/sbox/rbac/20-rbac.tf
+++ b/terraform/environment/sbox/rbac/20-rbac.tf
@@ -4,6 +4,7 @@ module "bastion-secops-sbox-rbac" {
     azurerm.bastion              = azurerm.bastion
     azurerm.soc                  = azurerm.soc
     azurerm.shared_image_gallery = azurerm.shared_image_gallery
+    azuread                      = azuread
 
   }
   depends_on = [

--- a/terraform/environment/sbox/rbac/20-rbac.tf
+++ b/terraform/environment/sbox/rbac/20-rbac.tf
@@ -1,7 +1,4 @@
 module "bastion-secops-sbox-rbac" {
-  depends_on = [
-    module.bastion-secops-sbox
-  ]
   source                          = "../../../modules/rbac/"
   bastion_vm_name                 = "bastion-secops-sbox"
   bastion_resource_group          = "bastion-sbox-rg"

--- a/terraform/environment/sbox/rbac/20-rbac.tf
+++ b/terraform/environment/sbox/rbac/20-rbac.tf
@@ -1,15 +1,5 @@
 module "bastion-secops-sbox-rbac" {
   source = "../../../modules/rbac/"
-  providers = {
-    azurerm.bastion              = azurerm.bastion
-    azurerm.soc                  = azurerm.soc
-    azurerm.shared_image_gallery = azurerm.shared_image_gallery
-    azuread                      = azuread
-
-  }
-  depends_on = [
-    module.bastion-secops-sbox
-  ]
   bastion_vm_name                 = "bastion-secops-sbox"
   bastion_resource_group          = "bastion-sbox-rg"
   bastion_access_admin_group_name = "DTS Non-Production Bastion Access for Administrators (SecOps)"

--- a/terraform/environment/sbox/rbac/20-rbac.tf
+++ b/terraform/environment/sbox/rbac/20-rbac.tf
@@ -1,4 +1,4 @@
-module "bastion-secops-rbac" {
+module "bastion-secops-sbox-rbac" {
   source                          = "../../../modules/rbac/"
   bastion_vm_name                 = "bastion-secops-sbox"
   bastion_resource_group          = "bastion-sbox-rg"

--- a/terraform/environment/sbox/rbac/20-rbac.tf
+++ b/terraform/environment/sbox/rbac/20-rbac.tf
@@ -1,4 +1,7 @@
 module "bastion-secops-sbox-rbac" {
+  depends_on = [
+    module.bastion-secops-sbox
+  ]
   source                          = "../../../modules/rbac/"
   bastion_vm_name                 = "bastion-secops-sbox"
   bastion_resource_group          = "bastion-sbox-rg"

--- a/terraform/environment/sbox/rbac/20-rbac.tf
+++ b/terraform/environment/sbox/rbac/20-rbac.tf
@@ -1,5 +1,11 @@
 module "bastion-secops-sbox-rbac" {
   source = "../../../modules/rbac/"
+  providers = {
+    azurerm.bastion              = azurerm.bastion
+    azurerm.soc                  = azurerm.soc
+    azurerm.shared_image_gallery = azurerm.shared_image_gallery
+
+  }
   depends_on = [
     module.bastion-secops-sbox
   ]

--- a/terraform/environment/sbox/rbac/20-rbac.tf
+++ b/terraform/environment/sbox/rbac/20-rbac.tf
@@ -1,3 +1,13 @@
+module "bastion-secops-rbac" {
+  source                          = "../../../modules/rbac/"
+  bastion_vm_name                 = "bastion-secops-sbox"
+  bastion_resource_group          = "bastion-sbox-rg"
+  bastion_access_admin_group_name = "DTS Non-Production Bastion Access for Administrators (SecOps)"
+  bastion_access_user_group_name  = "DTS Non-Production Bastion Access for Users (SecOps)"
+  bastion_subscription_id         = "2b1afc19-5ca9-4796-a56f-574a58670244"
+  aad_role_def_id_admin           = "/subscriptions/b3394340-6c9f-44ca-aa3e-9ff38bd1f9ac/providers/Microsoft.Authorization/roleDefinitions/1c0163c0-47e6-4577-8991-ea5c82e286e4"
+  aad_role_def_id_user            = "/subscriptions/b3394340-6c9f-44ca-aa3e-9ff38bd1f9ac/providers/Microsoft.Authorization/roleDefinitions/fb879df8-f326-4884-b1cf-06f3ad86be52"
+}
 module "bastion-sbox-rbac" {
   source                          = "../../../modules/rbac/"
   bastion_vm_name                 = "bastion-sbox"

--- a/terraform/modules/rbac/21-role-assignment.tf
+++ b/terraform/modules/rbac/21-role-assignment.tf
@@ -1,7 +1,7 @@
 resource "azurerm_role_assignment" "bastion-admin" {
   provider = azurerm.bastion
   depends_on = [
-    module.bastion-secops-sbox
+    azurerm_linux_virtual_machine.bastion
   ]
   scope              = data.azurerm_virtual_machine.bastion.id
   role_definition_id = var.aad_role_def_id_admin
@@ -11,7 +11,7 @@ resource "azurerm_role_assignment" "bastion-admin" {
 resource "azurerm_role_assignment" "bastion-user" {
   provider = azurerm.bastion
   depends_on = [
-    module.bastion-secops-sbox
+    azurerm_linux_virtual_machine.bastion
   ]
   scope              = data.azurerm_virtual_machine.bastion.id
   role_definition_id = var.aad_role_def_id_user

--- a/terraform/modules/rbac/21-role-assignment.tf
+++ b/terraform/modules/rbac/21-role-assignment.tf
@@ -1,8 +1,5 @@
 resource "azurerm_role_assignment" "bastion-admin" {
   provider = azurerm.bastion
-  depends_on = [
-    azurerm_linux_virtual_machine.bastion
-  ]
   scope              = data.azurerm_virtual_machine.bastion.id
   role_definition_id = var.aad_role_def_id_admin
   principal_id       = data.azuread_group.bastion-admin.id
@@ -10,9 +7,6 @@ resource "azurerm_role_assignment" "bastion-admin" {
 
 resource "azurerm_role_assignment" "bastion-user" {
   provider = azurerm.bastion
-  depends_on = [
-    azurerm_linux_virtual_machine.bastion
-  ]
   scope              = data.azurerm_virtual_machine.bastion.id
   role_definition_id = var.aad_role_def_id_user
   principal_id       = data.azuread_group.bastion-user.id

--- a/terraform/modules/rbac/21-role-assignment.tf
+++ b/terraform/modules/rbac/21-role-assignment.tf
@@ -1,6 +1,8 @@
 resource "azurerm_role_assignment" "bastion-admin" {
   provider = azurerm.bastion
-
+  depends_on = [
+    module.bastion-secops-sbox
+  ]
   scope              = data.azurerm_virtual_machine.bastion.id
   role_definition_id = var.aad_role_def_id_admin
   principal_id       = data.azuread_group.bastion-admin.id
@@ -8,7 +10,9 @@ resource "azurerm_role_assignment" "bastion-admin" {
 
 resource "azurerm_role_assignment" "bastion-user" {
   provider = azurerm.bastion
-
+  depends_on = [
+    module.bastion-secops-sbox
+  ]
   scope              = data.azurerm_virtual_machine.bastion.id
   role_definition_id = var.aad_role_def_id_user
   principal_id       = data.azuread_group.bastion-user.id

--- a/terraform/modules/rbac/21-role-assignment.tf
+++ b/terraform/modules/rbac/21-role-assignment.tf
@@ -1,12 +1,12 @@
 resource "azurerm_role_assignment" "bastion-admin" {
-  provider = azurerm.bastion
+  provider           = azurerm.bastion
   scope              = data.azurerm_virtual_machine.bastion.id
   role_definition_id = var.aad_role_def_id_admin
   principal_id       = data.azuread_group.bastion-admin.id
 }
 
 resource "azurerm_role_assignment" "bastion-user" {
-  provider = azurerm.bastion
+  provider           = azurerm.bastion
   scope              = data.azurerm_virtual_machine.bastion.id
   role_definition_id = var.aad_role_def_id_user
   principal_id       = data.azuread_group.bastion-user.id


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DTSPO-8020](https://tools.hmcts.net/jira/browse/DTSPO-8020)


### Change description ###
PR to create a new bastion server 'bastion-secops-sbox' for access Splunk SBOX environment; this is to reduce the need for retrieving and calling private keys in order to access this environment, which should in turn provide better security. Access Package `SecOps Sandbox (SBOX) Bastion Server Access` and groups have been created manually alongside this.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
