### PR TITLE
DTSPO-12351 - Apply latest image to bastion prod and update SKU size …

### DIFF
--- a/terraform/environment/prod/10-locals.tf
+++ b/terraform/environment/prod/10-locals.tf
@@ -1,7 +1,7 @@
 locals {
   environment             = "prod"
   location                = "uksouth"
-  image_version           = "1.0.3"
+  image_version           = "1.0.5"
   subnet                  = "10.48.0.0/27"
   jumpbox_subnet          = "10.48.2.0/28"
   hub_subscription_id     = "0978315c-75fe-4ada-9d11-1eb5e0e0b214"

--- a/terraform/modules/bastion/21-virtual-machine.tf
+++ b/terraform/modules/bastion/21-virtual-machine.tf
@@ -11,7 +11,7 @@ resource "azurerm_linux_virtual_machine" "bastion" {
   resource_group_name = var.resource_group_name
   location            = var.location
   tags                = module.ctags.common_tags
-  size                = "Standard_D2ds_v4"
+  size                = "Standard_D4ds_v5"
   admin_username      = var.bastion_username
   network_interface_ids = [
     azurerm_network_interface.bastion.id,


### PR DESCRIPTION
…for all envs

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
DTSPO-12351 & DTSPO-12706


### Change description ###
DTSPO-12351 & DTSPO-12706 - Bastion Prod OS image (PSQL v15 and OpenJDK v17 (existing version 11 still exists)) & SKU size upgrade from D2ds v4 to d4ds v5 for all environments.  Note the Bastion nodes will be rebuilt so scheduling Bastion prod on 28th Feb after 18:00


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
