### PR TITLE
fix: remove workaround put in place for ITHC testers

### DIFF
--- a/terraform/environment/nonprod/rbac/20-rbac.tf
+++ b/terraform/environment/nonprod/rbac/20-rbac.tf
@@ -7,10 +7,4 @@ module "bastion-dev-rbac" {
   bastion_subscription_id         = "b44eb479-9ae2-42e7-9c63-f3c599719b6f"
   aad_role_def_id_admin           = "/subscriptions/b44eb479-9ae2-42e7-9c63-f3c599719b6f/providers/Microsoft.Authorization/roleDefinitions/1c0163c0-47e6-4577-8991-ea5c82e286e4"
   aad_role_def_id_user            = "/subscriptions/b44eb479-9ae2-42e7-9c63-f3c599719b6f/providers/Microsoft.Authorization/roleDefinitions/fb879df8-f326-4884-b1cf-06f3ad86be52"
-  aad_workaround_users = [
-    "aaefee8a-5409-4156-bcda-76171e1ca833",
-    "ffb2cb96-d318-48c8-bfd4-b7d8c38743d8",
-    "d64330dc-2970-4da8-adf8-beec5126c666",
-    "cc2d6a5d-5e54-4d39-ba3a-01fc0da9545c"
-  ]
 }

--- a/terraform/modules/rbac/10-variables.tf
+++ b/terraform/modules/rbac/10-variables.tf
@@ -32,9 +32,3 @@ variable "aad_role_def_id_user" {
   description = "The role definition ID for Virtual Machine User Login"
   type        = string
 }
-
-variable "aad_workaround_users" {
-  description = "List of user IDs to grant user access to the bastion VM whilst JIT is not working. This will unblock ITHC testers."
-  type        = list(string)
-  default     = []
-}

--- a/terraform/modules/rbac/21-role-assignment.tf
+++ b/terraform/modules/rbac/21-role-assignment.tf
@@ -11,11 +11,3 @@ resource "azurerm_role_assignment" "bastion-user" {
   role_definition_id = var.aad_role_def_id_user
   principal_id       = data.azuread_group.bastion-user.id
 }
-
-resource "azurerm_role_assignment" "bastion-user-workaround" {
-  for_each           = toset(var.aad_workaround_users)
-  provider           = azurerm.bastion
-  scope              = data.azurerm_virtual_machine.bastion.id
-  role_definition_id = var.aad_role_def_id_user
-  principal_id       = each.value
-}


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
Remove workaround put in place to allow ITHC testers whilst work on the JIT packages was ongoing.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
