### PR TITLE
Fix agentPool

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -49,7 +49,7 @@ pr:
 
 variables:
   terraformVersion: 1.5.6
-  agentPool: ubuntu-20.04
+  agentPool: ubuntu-24.04
 
 stages:
   - ${{ each bastion in parameters.bastionHosts }}:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -49,7 +49,7 @@ pr:
 
 variables:
   terraformVersion: 1.5.6
-  agentPool: ubuntu-24.04
+  agentPool: ubuntu-latest
 
 stages:
   - ${{ each bastion in parameters.bastionHosts }}:
@@ -64,6 +64,8 @@ stages:
 
           steps:
             - template: pipeline-templates/terraform-test.yaml
+              parameters:
+                terraformVersion: ${{ variables.terraformVersion }}
 
             - template: pipeline-templates/terraform-execute.yaml
               parameters:

--- a/pipeline-templates/terraform-test.yaml
+++ b/pipeline-templates/terraform-test.yaml
@@ -1,3 +1,7 @@
+parameters:
+  - name: terraformVersion
+    type: string
+    
 steps:
 
 - task: TerraformInstaller@0

--- a/pipeline-templates/terraform-test.yaml
+++ b/pipeline-templates/terraform-test.yaml
@@ -1,5 +1,10 @@
 steps:
 
+- task: TerraformInstaller@0
+  displayName: Terraform install test
+  inputs:
+    terraformVersion: ${{ parameters.terraformVersion }}
+
 - task: PowerShell@2
   displayName: Run tests
   inputs:


### PR DESCRIPTION
### Change description

agentPool isn't working as `20.04` is now EOL
Terraform must be installed on test task as this is no longer included in the vmImage

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
